### PR TITLE
fix: settings window size on small screens + multi-display support

### DIFF
--- a/notchprompt/AppDelegate.swift
+++ b/notchprompt/AppDelegate.swift
@@ -76,6 +76,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
             }
             .store(in: &cancellables)
 
+        model.$targetScreenID
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.overlayController?.reposition()
+            }
+            .store(in: &cancellables)
+
         Publishers.MergeMany(
             model.$script.map { _ in () }.eraseToAnyPublisher(),
             model.$isRunning.map { _ in () }.eraseToAnyPublisher(),

--- a/notchprompt/PrompterModel.swift
+++ b/notchprompt/PrompterModel.swift
@@ -39,6 +39,8 @@ Tip: Use the menu bar icon to start/pause or reset the scroll.
     @Published var overlayHeight: Double = 150
     @Published var backgroundOpacity: Double = 1.0
     @Published var scrollMode: ScrollMode = .infinite
+    // 0 = auto (prefer built-in display); non-zero = specific CGDirectDisplayID chosen by user.
+    @Published var targetScreenID: UInt32 = 0
     // Fraction of the viewport height to fade at top and bottom.
     let edgeFadeFraction: Double = 0.20
 
@@ -67,6 +69,7 @@ Tip: Use the menu bar icon to start/pause or reset the scroll.
         static let backgroundOpacity = "backgroundOpacity"
         static let countdownSeconds = "countdownSeconds"
         static let scrollMode = "scrollMode"
+        static let targetScreenID = "targetScreenID"
     }
 
     private init() {}
@@ -218,6 +221,7 @@ Tip: Use the menu bar icon to start/pause or reset the scroll.
         } else {
             scrollMode = .infinite
         }
+        targetScreenID = UInt32(defaults.integer(forKey: DefaultsKey.targetScreenID))
     }
 
     func saveToDefaults() {
@@ -233,6 +237,7 @@ Tip: Use the menu bar icon to start/pause or reset the scroll.
         defaults.set(backgroundOpacity, forKey: DefaultsKey.backgroundOpacity)
         defaults.set(countdownSeconds, forKey: DefaultsKey.countdownSeconds)
         defaults.set(scrollMode.rawValue, forKey: DefaultsKey.scrollMode)
+        defaults.set(Int(targetScreenID), forKey: DefaultsKey.targetScreenID)
     }
 
     private func beginCountdown(seconds: Int) {

--- a/notchprompt/SettingsWindowController.swift
+++ b/notchprompt/SettingsWindowController.swift
@@ -14,8 +14,14 @@ final class SettingsWindowController: NSWindowController {
         let root = ContentView()
         let hosting = NSHostingController(rootView: root)
 
+        // Cap the initial window height to the available screen space so it
+        // fits on smaller MacBook screens (e.g. 13" with ~800pt visible height).
+        let availableHeight = NSScreen.main?.visibleFrame.height ?? 860
+        let windowHeight = min(860, availableHeight - 40)
+        let minHeight = min(760, windowHeight)
+
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 780, height: 860),
+            contentRect: NSRect(x: 0, y: 0, width: 780, height: windowHeight),
             styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
@@ -23,7 +29,7 @@ final class SettingsWindowController: NSWindowController {
         window.title = "Notchprompt Settings"
         window.contentViewController = hosting
         window.isReleasedWhenClosed = false
-        window.minSize = NSSize(width: 700, height: 760)
+        window.minSize = NSSize(width: 700, height: minHeight)
         window.setFrameAutosaveName("NotchpromptSettingsWindow")
         window.center()
 


### PR DESCRIPTION
- SettingsWindowController: cap initial window height to available screen height minus 40pt so the settings window fits on 13" MacBooks instead of being clipped off-screen (fixes #3)

- OverlayWindowController: prefer CGDisplayIsBuiltin() over CGMainDisplayID() so the overlay always targets the MacBook notch screen even when the user has promoted an external monitor to "main display" (fixes #4)

- PrompterModel: add targetScreenID (UInt32, default 0 = auto) persisted to UserDefaults

- ContentView: add Display picker in Prompter settings listing all connected screens by name; selecting a screen moves the overlay immediately; list auto-refreshes when monitors are connected/disconnected

- AppDelegate: observe targetScreenID changes and call reposition() so switching displays in Settings takes effect instantly without restarting