### PR TITLE
Fix 5 bugs from code review (#14–#18)

### DIFF
--- a/notchprompt.xcodeproj/project.pbxproj
+++ b/notchprompt.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -297,6 +298,7 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/notchprompt/AppDelegate.swift
+++ b/notchprompt/AppDelegate.swift
@@ -20,6 +20,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     private var settingsWindowController: SettingsWindowController?
     private var scriptEditorWindowController: ScriptEditorWindowController?
     private var cancellables: Set<AnyCancellable> = []
+    private var editKeyMonitor: Any?
 
     private var startPauseItem: NSMenuItem?
     private var showOverlayItem: NSMenuItem?
@@ -53,6 +54,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     func applicationWillTerminate(_ notification: Notification) {
         model.saveToDefaults()
         hotkeyManager.unregisterAll()
+        if let editKeyMonitor {
+            NSEvent.removeMonitor(editKeyMonitor)
+            self.editKeyMonitor = nil
+        }
         cancellables.removeAll()
     }
 
@@ -245,7 +250,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     // MARK: - Edit key handler (Cmd+C/V/X/A/Z bypass for menu-bar apps)
 
     private func installEditKeyHandler() {
-        NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+        editKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             guard event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command ||
                   event.modifierFlags.intersection(.deviceIndependentFlagsMask) == [.command, .shift] else {
                 return event

--- a/notchprompt/OverlayWindowController.swift
+++ b/notchprompt/OverlayWindowController.swift
@@ -106,7 +106,7 @@ final class OverlayWindowController {
 #endif
         if isVisible {
             // Ensure the panel can reappear even when the app is backgrounded.
-            reposition()
+            reposition(animated: true)
             panel.level = .screenSaver
             panel.alphaValue = 1.0
             panel.orderFrontRegardless()
@@ -119,7 +119,7 @@ final class OverlayWindowController {
 #endif
     }
 
-    func reposition() {
+    func reposition(animated: Bool = false) {
         guard let screen = targetScreen() ?? NSScreen.main ?? NSScreen.screens.first else { return }
 
         let width = CGFloat(model.overlayWidth)
@@ -142,20 +142,12 @@ final class OverlayWindowController {
         )
 #endif
 
-        let shouldAnimate: Bool
-        if let lastFrame {
-            let movedEnough = abs(lastFrame.origin.x - targetFrame.origin.x) > 0.5 ||
-                abs(lastFrame.origin.y - targetFrame.origin.y) > 0.5
-            let resizedEnough = abs(lastFrame.size.width - targetFrame.size.width) > 0.5 ||
-                abs(lastFrame.size.height - targetFrame.size.height) > 0.5
-            shouldAnimate = movedEnough || resizedEnough
-        } else {
-            shouldAnimate = false
-        }
-
-        panel.setFrame(targetFrame, display: true, animate: shouldAnimate)
+        // Only animate on explicit, discrete transitions (e.g. showing the overlay).
+        // Slider-driven geometry changes arrive in a 16 ms-throttled stream and would
+        // stack overlapping animations if animated (see #17).
+        panel.setFrame(targetFrame, display: true, animate: animated)
         lastFrame = targetFrame
-        
+
         // Ensure level is re-applied in case something reset it
         panel.level = .screenSaver
         panel.alphaValue = 1.0

--- a/notchprompt/PrompterModel.swift
+++ b/notchprompt/PrompterModel.swift
@@ -258,12 +258,13 @@ Tip: Use the menu bar icon to start/pause or reset the scroll.
         let trimmed = script.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return 0 }
 
+        // Reading duration is how long it takes to read the script aloud at a
+        // typical 160 words/minute. It is independent of the scroll speed
+        // (a layout/geometric quantity); mixing the two produced meaningless
+        // numbers (see #18).
         let words = max(1, trimmed.split(whereSeparator: \.isWhitespace).count)
-        // Approximation: 160 words/minute baseline adjusted by current speed.
         let baselineWPM = 160.0
-        let speedFactor = speedPointsPerSecond / Self.speedPresetNormal
-        let adjustedWPM = max(60, baselineWPM * speedFactor)
-        let minutes = Double(words) / adjustedWPM
+        let minutes = Double(words) / baselineWPM
         return minutes * 60
     }
 

--- a/notchprompt/ScrollingTextView.swift
+++ b/notchprompt/ScrollingTextView.swift
@@ -161,9 +161,13 @@ struct ScrollingTextView: View {
                     resetPhase()
                 }
                 .onChange(of: text) { _, _ in
+                    // Content changed: re-measure height and re-anchor only if we
+                    // are sitting at the very top. Do NOT reset the phase — that
+                    // would snap a running read back to line 1 (see #15). Explicit
+                    // resets route through `resetToken` / `model.resetScroll()`.
                     hasMeasuredContentHeight = false
                     deferredStopTargetPhase = nil
-                    resetPhase()
+                    normalizeTopAnchorIfNearStart()
                 }
                 .onChange(of: jumpBackToken) { _, _ in
                     guard hasContent else { return }


### PR DESCRIPTION
## Summary

Fixes the five issues opened from the code review (#14–#18). Each fix is one commit; all are independent and localized. Verified with a clean Debug build (`xcodebuild` succeeded, zero warnings).

| Commit | Issue | Fix |
| --- | --- | --- |
| `fix(dock)` | #14 | Add `INFOPLIST_KEY_LSUIElement=YES` (Debug + Release) so the menu-bar utility no longer shows a Dock tile. Verified `LSUIElement=true` lands in the built `Info.plist`. |
| `fix(scroll)` | #15 | `onChange(of: text)` no longer calls `resetPhase()`; it re-measures height and re-anchors only when already at the top. Editing the script mid-read no longer snaps the overlay to line 1. Explicit resets still flow through `resetToken`. |
| `fix(leak)` | #16 | Store the `NSEvent` local monitor token and `removeMonitor` it in `applicationWillTerminate`. |
| `fix(perf)` | #17 | `reposition(animated:)` defaults to non-animated; only `setVisible(true)` animates. Dragging the width/height sliders no longer stacks overlapping window animations. |
| `fix(estimate)` | #18 | `estimatedReadDuration` uses a fixed 160 WPM instead of mixing `speedPointsPerSecond` (px/s) with words-per-minute. The estimate now reflects how long it takes to read the script aloud. |

## Verification

```bash
xcodebuild -project notchprompt.xcodeproj -scheme notchprompt -configuration Debug build
# ** BUILD SUCCEEDED **  (no warnings)
/usr/libexec/PlistBuddy -c "Print :LSUIElement" …/notchprompt.app/Contents/Info.plist
# true
```

## Notes / out of scope

- #18 uses the simpler "fixed WPM" option from the issue rather than the geometric (`contentHeight / speed`) option, to avoid wiring a new `contentHeight` channel from `ScrollingTextView` back into the model. Happy to switch if the maintainer prefers the geometric model.
- Did not touch the unrelated `speedPresetSlow/Fast` / `applySpeedPreset` unused-API warnings (pre-existing, not introduced here).
- Behavior changes worth a quick manual smoke-test: (a) Dock icon should be gone on launch; (b) overlay should resize crisply while dragging sliders; (c) editing the running script should keep position; (d) Cmd+C/V/X/A in the script editor unaffected after the monitor-lifetime change.

Closes #14, closes #15, closes #16, closes #17, closes #18.
